### PR TITLE
Add check for undefined value for sorting mechanism

### DIFF
--- a/src/tree-grid-directive.js
+++ b/src/tree-grid-directive.js
@@ -252,7 +252,7 @@
                             }
 
                             var key = function (x) {
-                                return (x[col.field] === null ? "" : x[col.field].toLowerCase());
+                                return ((x[col.field] === null || x[col.field] === undefined) ? "" : x[col.field].toLowerCase());
                             };
 
                             switch (col.sortingType) {


### PR DESCRIPTION
Sorting wont throw exception during sorting, when branch does not have
value for given field